### PR TITLE
Support for read operations on /dev/null as a Service

### DIFF
--- a/content/code.txt
+++ b/content/code.txt
@@ -33,6 +33,9 @@ The configuration looks pretty much like
         if ($request_method = POST ) {
           return 200;
         }
+        if ($request_method = GET ) {
+          return 204;
+        }
     }
 
 But we think your data is worth it. 


### PR DESCRIPTION
This is an enhancement request for DaaS to support read operation.

On many traditional Unix-like systems, /dev/null is not only a trash bin but a handy source of EOFs or an empty file.
Supporting read operation on /dev/null as a Service makes it easy for the users of on-premises /dev/null's to migrate to the DaaS.

With this enhancement you can create an empty file using DaaS:

``` sh
wget -O new_empty_file http://.../dev/null
```
