### PR TITLE
Retire unlimited plan

### DIFF
--- a/content/pricing.md
+++ b/content/pricing.md
@@ -36,9 +36,9 @@ Simply contact one of our sales guys to get in touch!
 </tr>
 <tr>
 <td>Enterprise</td>
-<td>UNLIMITED!</td>
+<td>More than 500GB/Month</td>
 <td>High Availability devnull Cluster</td>
-<td>$500</td>
+<td>Contact us for pricing</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
We've found that a handful of companies have been able to use disproportionate resources in our unlimited plan. To ensure quality service, we are retiring the unlimited plan and offering bespoke contracts to companies with large data discarding needs.